### PR TITLE
go back to one main runtime

### DIFF
--- a/.changeset/fast-geese-think.md
+++ b/.changeset/fast-geese-think.md
@@ -1,0 +1,7 @@
+---
+"@guzzler/webui": patch
+---
+
+reintegrate the frontend runtime into one
+
+turns out splitting it didn't change the bundle size like i assumed it did

--- a/packages/webui/src/App.tsx
+++ b/packages/webui/src/App.tsx
@@ -20,7 +20,7 @@ import {
   Unauthenticated,
   useCurrentSessionInfo,
 } from "./contexts/GlobalContext.js";
-import { makeRunFunctions } from "./internal/bootstrap.js";
+import { runFork, runP } from "./internal/bootstrap.js";
 import { LoginPage } from "./pages/LoginPage.js";
 import {
   PagesRoute,
@@ -32,8 +32,6 @@ import {
 
 const SignupPage = lazy(() => import("./pages/SignupPage.js"));
 const LoggedInApp = lazy(() => import("./pages/LoggedInApp.js"));
-
-const { runP, runFork } = makeRunFunctions(SessionClient.Default);
 
 const LoggedInAppWrapper = ({ route }: { route: PagesRoute }) => {
   const session = useCurrentSessionInfo();

--- a/packages/webui/src/contexts/UserDataContext.tsx
+++ b/packages/webui/src/contexts/UserDataContext.tsx
@@ -1,16 +1,11 @@
-import { Effect, Fiber, Layer, pipe, Stream } from "effect";
+import { Effect, Fiber, pipe, Stream } from "effect";
 import { gen } from "effect/Effect";
 import { PropsWithChildren, useEffect, useState } from "react";
-import { AutosClient } from "../apiclients/AutosClient.js";
 import { AutosDataRepository } from "../data/AutosDataRepository.js";
-import { makeRunFunctions } from "../internal/bootstrap.js";
+import { runFork, runP } from "../internal/bootstrap.js";
 import * as internal from "../internal/contexts/userDataContext.js";
 import * as Model from "../models/UserDataContext.js";
 import { useSucceededGlobalContext_Unsafe } from "./GlobalContext.js";
-
-const { runP, runFork } = makeRunFunctions(
-  AutosDataRepository.Default.pipe(Layer.provideMerge(AutosClient.Default)),
-);
 
 export const UserDataContextProvider = ({ children }: PropsWithChildren) => {
   const { setConnected } = useSucceededGlobalContext_Unsafe();

--- a/packages/webui/src/pages/HomePage.tsx
+++ b/packages/webui/src/pages/HomePage.tsx
@@ -3,10 +3,8 @@ import { AccountClient } from "../apiclients/AccountClient.js";
 import reactLogo from "../assets/react.svg";
 import { StandardPageBox } from "../components/StandardPageBox.js";
 import { useTranslation } from "../i18n.js";
-import { makeRunFunctions } from "../internal/bootstrap.js";
 import viteLogo from "/vite.svg";
-
-const { runP } = makeRunFunctions(AccountClient.Default);
+import { runP } from "../internal/bootstrap.js";
 
 const HomePage = () => {
   const { t } = useTranslation();

--- a/packages/webui/src/pages/ImportPage.tsx
+++ b/packages/webui/src/pages/ImportPage.tsx
@@ -41,14 +41,12 @@ import GPlayLogo from "../assets/Google_Play_2022_logo.svg?react";
 import { StandardPageBox } from "../components/StandardPageBox.js";
 import { VisuallyHiddenInput } from "../components/VisuallyHiddenInput.js";
 import { TFunction, useTranslation } from "../i18n.js";
-import { makeRunFunctions } from "../internal/bootstrap.js";
+import { runP } from "../internal/bootstrap.js";
 import { routes } from "../router.js";
 import { onEnterKey } from "../utils/onEnterKey.js";
 
 const MobileInfoIconP = () => import("../components/MobileInfoIcon.js");
 const MobileInfoIcon = lazy(MobileInfoIconP);
-
-const { runP } = makeRunFunctions(AutosClient.Default);
 
 type AbpErrorDialogProps = Readonly<{
   error: AutosModel.AbpImportError | RedactedError;

--- a/packages/webui/src/pages/SettingsPage.tsx
+++ b/packages/webui/src/pages/SettingsPage.tsx
@@ -30,11 +30,9 @@ import {
 import { PreferencesClient } from "../apiclients/PreferencesClient.js";
 import { StandardPageBox } from "../components/StandardPageBox.js";
 import { useTranslation } from "../i18n.js";
-import { makeRunFunctions } from "../internal/bootstrap.js";
+import { runP } from "../internal/bootstrap.js";
 import SecureUserPreferencesFields = SecureUserPreferences.SecureUserPreferencesFields;
 import SecureUserPreferencesPatch = SecureUserPreferences.SecureUserPreferencesPatch;
-
-const { runP } = makeRunFunctions(PreferencesClient.Default);
 
 type GMapsDialogProps = Readonly<{
   open: boolean;

--- a/packages/webui/src/pages/SignupPage.tsx
+++ b/packages/webui/src/pages/SignupPage.tsx
@@ -33,12 +33,10 @@ import React, {
 import { SignupClient } from "../apiclients/SignupClient.js";
 import { useCountdown } from "../hooks/useCountdown.js";
 import { useTranslation } from "../i18n.js";
-import { makeRunFunctions } from "../internal/bootstrap.js";
+import { runP } from "../internal/bootstrap.js";
 import { routes, SignupRoute } from "../router.js";
 import { logout } from "../utils/logout.js";
 import { onEnterKey } from "../utils/onEnterKey.js";
-
-const { runP } = makeRunFunctions(SignupClient.Default);
 
 type CreateUserCardProps = Pick<Props, "userInfo"> &
   Readonly<{


### PR DESCRIPTION
turns out splitting up the runtime into dynamically-created ones does absolutely nothing for the main bundle size, they're functionally identical